### PR TITLE
Added verification prompt whenever user attempts to trash a song

### DIFF
--- a/Trashbin.cs
+++ b/Trashbin.cs
@@ -11,6 +11,9 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using System.Timers;
 using Newtonsoft.Json;
+using Synth.SongSelection;
+using TMPro;
+using UnityEngine.UI;
 
 namespace Trashbin
 {
@@ -26,180 +29,24 @@ namespace Trashbin
 
         Timer warnTimer = new Timer(2000);
 
-        public void DeleteSong(object sender, VRTK.InteractableObjectEventArgs e) 
+        public override void OnSceneWasInitialized(int buildIndex, string sceneName)
         {
-            // validation prompt?
-            //ssmInstance.OpenPromptPanel(0);
-            // get selected song
-            string imageFilePath;
-            List<string> blacklist = new List<string>();
-            Type ssm = typeof(Synth.SongSelection.SongSelectionManager);
-            FieldInfo ssmInstanceInfo = ssm.GetField("s_instance", BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static);
-            Synth.SongSelection.SongSelectionManager ssmInstance = (Synth.SongSelection.SongSelectionManager)ssmInstanceInfo.GetValue(null);
-            int count = 0;
-            bool isDuplicate = false;
-
-            if (ssmInstance.SelectedGameTrack.IsCustomSong)
+            var mainMenuScenes = new List<string>()
             {
-                string filePath = ssmInstance.SelectedGameTrack.FilePath;
+                "01.The Room",
+                "02.The Void",
+                "03.Roof Top",
+                "04.The Planet",
+                "SongSelection"
+            };
+            base.OnSceneWasInitialized(buildIndex, sceneName);
 
-                MelonLogger.Msg(filePath);
-                if (filePath == null)
-                {
-                    return;
-                }
-                FileInfo synthFile = new FileInfo(filePath);
-                MelonLogger.Msg("Deleting custom song");
-                // gametrack?
-
-                // remove from DB
-                SynthsFinder sf_instance = SynthsFinder.s_instance;
-                string mainDirPath = Application.dataPath + "/../";
-                MelonLogger.Msg(mainDirPath);
-                Type typeSF = typeof(SynthsFinder);
-                try
-                {
-                    if (sf_instance.Dbcon == null)
-                    {
-                        string connectionString = "URI=file:" + mainDirPath + "/SynthDB";
-                        sf_instance.Dbcon = new SqliteConnection(connectionString);
-                        sf_instance.Dbcon.Open();
-                    }
-
-                    //setup db connection
-                    MelonLogger.Msg("Opened DB connection");
-                    IDbConnection dbcon = (IDbConnection)sf_instance.Dbcon;
-                    IDbCommand dbCommand = dbcon.CreateCommand();
-                    IDbCommand cmndReadFile = dbcon.CreateCommand();
-                    IDbCommand cmndReadImg = dbcon.CreateCommand();
-                    IDataReader readerFile;
-                    IDataReader readerImg;
-                    FieldInfo dbTableNameField = typeSF.GetField("dbTableName", BindingFlags.NonPublic | BindingFlags.Instance);
-
-                    //get song info from DB
-                    string queryGetFile = "SELECT image_file FROM " + dbTableNameField.GetValue(sf_instance) + " WHERE file_name='" + synthFile.Name + "'"; // private field dbTableName
-                    MelonLogger.Msg(queryGetFile);
-                    cmndReadFile.CommandText = queryGetFile;
-                    readerFile = cmndReadFile.ExecuteReader();
-                    readerFile.Read();
-                    imageFilePath = readerFile[0].ToString();
-                    readerFile.Close();
-
-                    //check for duplicate image files
-                    string queryGetImg = "SELECT image_file FROM " + dbTableNameField.GetValue(sf_instance) + " WHERE image_file='" + imageFilePath + "'"; // private field dbTableName
-                    MelonLogger.Msg(queryGetImg);
-                    cmndReadFile.CommandText = queryGetImg;
-                    readerImg = cmndReadFile.ExecuteReader();
-                    while (readerImg.Read())
-                    {
-                        count = count + 1;
-                    }
-                    readerImg.Close();
-                    if (count > 1)
-                    {
-                        isDuplicate = true;
-                    }
-
-                    //delete song info from db
-                    MelonLogger.Msg("Creating query");
-                    string queryDelete = "DELETE FROM " + dbTableNameField.GetValue(sf_instance) + " WHERE file_name='" + synthFile.Name + "'"; // private field dbTableName
-                    MelonLogger.Msg(queryDelete);
-                    dbCommand.CommandText = queryDelete;
-                    MelonLogger.Msg("Executing query");
-                    dbCommand.ExecuteNonQuery();
-                    MelonLogger.Msg("Deleted song from DB");
-                }
-                catch (Exception ex)
-                {
-                    MelonLogger.Msg("Failed to access DB");
-                    MelonLogger.Msg(ex);
-
-                    if (sf_instance.Dbcon != null)
-                    {
-                        sf_instance.Dbcon.Close();
-                    }
-                    sf_instance.Dbcon = null;
-                    return;
-                }
-
-                // delete synth-file
-                FieldInfo isSongLoadedField = ssm.GetField("waitForSongsLoad", BindingFlags.NonPublic | BindingFlags.Instance);
-                while ((bool)isSongLoadedField.GetValue(ssmInstance))
-                {
-                    Task.Delay(100);
-                }
-                try
-                {
-                    if (File.Exists(filePath))
-                    {
-                        File.Delete(filePath);
-                        MelonLogger.Msg("Deleted synth file " + ssmInstance.SelectedGameTrack.m_name);
-                    }
-                    if (!isDuplicate)
-                    {
-                        if (File.Exists(mainDirPath + "/NmBlacklist.json"))
-                        {
-                            blacklist = JsonConvert.DeserializeObject<List<string>>(File.ReadAllText(mainDirPath + "/NmBlacklist.json"));
-                            blacklist.Add(synthFile.Name);
-                            MelonLogger.Msg("test");
-                            File.WriteAllText(mainDirPath + "/NmBlacklist.json", JsonConvert.SerializeObject(blacklist));
-                        }
-                        else
-                        {
-                            StreamWriter blacklistStream = File.AppendText(mainDirPath + "/NmBlacklist.json");
-                            blacklist.Add(synthFile.Name);
-                            blacklistStream.Write(JsonConvert.SerializeObject(blacklist));
-                            blacklistStream.Close();
-                        }
-                    }                                 
-                }
-                catch (Exception ex)
-                {
-                    MelonLogger.Msg("Loading ongoing");
-                    MelonLogger.Msg(ex);
-                    return;
-                }
-
-                //Delete coresponding image file and leftover audio file
-                if (File.Exists(imageFilePath) & (!isDuplicate))
-                {
-                    File.Delete(imageFilePath);
-                    MelonLogger.Msg("Deleted image file");
-                }
-
-                Type sf = typeof(SynthsFinder);
-                FieldInfo audioFilePathField = sf.GetField("AudioFileCachePath", BindingFlags.NonPublic | BindingFlags.Instance);
-                string audioFilePath = (string)audioFilePathField.GetValue(sf_instance);
-
-                // reload song list 
-                ssmInstance.RefreshSongList(false);
-                MelonLogger.Msg("Updated song list"); // use RefreshCustomSongs() instead?
-                                
-            }
-            else
-            {
-                GameObject deleteButton = GameObject.Find("DeleteSongButton");
-                Transform tooltip = deleteButton.transform.Find("Tooltip");
-                Transform tooltipText = tooltip.Find("Text");
-                tooltipText.GetComponentInChildren<TMPro.TMP_Text>().text = "Can't delete OST songs";
-                MelonLogger.Msg("Can't delete OST songs");
-                warnTimer.Elapsed += new ElapsedEventHandler(TimerEvent);
-                warnTimer.AutoReset = true;
-                warnTimer.Start();
-            }
-        }
-
-        public void TimerEvent(object sender, ElapsedEventArgs e)
-        {
-            GameObject deleteButton = GameObject.Find("DeleteSongButton");
-            Transform tooltip = deleteButton.transform.Find("Tooltip");
-            Transform tooltipText = tooltip.Find("Text");
-            tooltipText.GetComponentInChildren<TMPro.TMP_Text>().text = "Delete current song";
-            warnTimer.Stop();
+            if (mainMenuScenes.Contains(sceneName)) ButtonInit();
         }
 
         private static void ButtonInit()
         {
+            MelonLogger.Msg("Adding button...");
             //bool twitchCredentials = false;
             var cs_instance = new Trashbin();
 
@@ -223,7 +70,7 @@ namespace Trashbin
             iconTexture.name = "bt-Close-X";
             Sprite iconSprite = Sprite.Create(iconTexture, new Rect(0, 0.0f, iconTexture.width, iconTexture.height), new Vector2(0.5f, 0.5f));
             iconSprite.name = "bt-X";
-            deleteIcon.GetComponent<SpriteRenderer>().sprite = iconSprite;            
+            deleteIcon.GetComponent<SpriteRenderer>().sprite = iconSprite;
             deleteIcon.localScale = new Vector3(0.15f, 0.15f, 1);
 
 
@@ -260,25 +107,226 @@ namespace Trashbin
             buttonEvent.OnUse.RemoveAllListeners();
             buttonEvent.OnUse.SetPersistentListenerState(1, UnityEngine.Events.UnityEventCallState.Off);
             deleteButton.SetActive(true);
-            buttonEvent.OnUse.AddListener(cs_instance.DeleteSong);
-             MelonLogger.Msg("Button added");
+            buttonEvent.OnUse.AddListener(cs_instance.VerifyDelete);
+            MelonLogger.Msg("Button added");
 
+            cs_instance.AddEvents(); // add new events to the Two Buttons prompt's continue/cancel buttons
         }
-public override void OnSceneWasInitialized(int buildIndex, string sceneName)
+
+        public void AddEvents()
         {
-            var mainMenuScenes = new List<string>() 
+            try
             {
-                "01.The Room",
-                "02.The Void",
-                "03.Roof Top",
-                "04.The Planet",
-                "SongSelection"
-            };
-            base.OnSceneWasInitialized(buildIndex, sceneName);
-            
-            if (mainMenuScenes.Contains(sceneName)) ButtonInit();
+                SongSelectionManager ssmInstance = SongSelectionManager.GetInstance;
+                FieldInfo TwoButtonsPromptWrapField = ssmInstance.GetType().GetField("TwoButtonsPromptWrap", BindingFlags.NonPublic | BindingFlags.Instance);
+                GameObject TwoButtonsPromptWrap = (GameObject)TwoButtonsPromptWrapField.GetValue(ssmInstance);
+                Transform continueBtnT = TwoButtonsPromptWrap.transform.Find("continue button");
+                VRTK_InteractableObject_UnityEvents persistentEvents = null;
+                persistentEvents = continueBtnT.GetComponentInChildren<VRTK_InteractableObject_UnityEvents>();
+                persistentEvents.OnUse.AddListener(DeleteSong);
+            }
+            catch (NullReferenceException ex)
+            {
+                MelonLogger.Msg("Null reference exception: " + ex.Message);
+                MelonLogger.Msg("Stack Trace: " + ex.StackTrace);
+            }
         }
-        
+
+        public void VerifyDelete(object sender, VRTK.InteractableObjectEventArgs e)
+        {
+            try
+            {
+                SongSelectionManager ssmInstance = SongSelectionManager.GetInstance;
+                FieldInfo promptLabelField = ssmInstance.GetType().GetField("promptLabel", BindingFlags.NonPublic | BindingFlags.Instance);
+                TMP_Text promptLabel = (TMP_Text)promptLabelField.GetValue(ssmInstance);
+                promptLabel.SetText("Delete and blacklist this song?");
+
+                ssmInstance.OpenPromptPanel(99); // open the Prompt Panel with unique prompt target 99 that will avoid pre-existing event from calling unwanted methods
+
+            }
+            catch (NullReferenceException ex)
+            {
+                MelonLogger.Msg("Null reference exception: " + ex.Message);
+                MelonLogger.Msg("Stack Trace: " + ex.StackTrace);
+            }
+        }
+
+        public void DeleteSong(object sender, VRTK.InteractableObjectEventArgs e) 
+        {
+            SongSelectionManager ssmInstance = SongSelectionManager.GetInstance;
+            FieldInfo currentPromptField = ssmInstance.GetType().GetField("currentPompt", BindingFlags.NonPublic | BindingFlags.Instance); // Klugey typos!
+            int currentPrompt = (int)currentPromptField.GetValue(ssmInstance);
+
+            if (currentPrompt == 99) // since this method will also be called when the "continue button" is used in other contexts, this unique currentPrompt value will prevent this method from doing anything in those cases
+            {
+                // get selected song
+                string imageFilePath;
+                List<string> blacklist = new List<string>();
+                Type ssm = typeof(Synth.SongSelection.SongSelectionManager);
+
+                int count = 0;
+                bool isDuplicate = false;
+
+                if (ssmInstance.SelectedGameTrack.IsCustomSong)
+                {
+                    string filePath = ssmInstance.SelectedGameTrack.FilePath;
+
+                    MelonLogger.Msg(filePath);
+                    if (filePath == null)
+                    {
+                        return;
+                    }
+                    FileInfo synthFile = new FileInfo(filePath);
+                    MelonLogger.Msg("Deleting custom song");
+                    // gametrack?
+
+                    // remove from DB
+                    SynthsFinder sf_instance = SynthsFinder.s_instance;
+                    string mainDirPath = Application.dataPath + "/../";
+                    MelonLogger.Msg(mainDirPath);
+                    Type typeSF = typeof(SynthsFinder);
+                    try
+                    {
+                        if (sf_instance.Dbcon == null)
+                        {
+                            string connectionString = "URI=file:" + mainDirPath + "/SynthDB";
+                            sf_instance.Dbcon = new SqliteConnection(connectionString);
+                            sf_instance.Dbcon.Open();
+                        }
+
+                        //setup db connection
+                        MelonLogger.Msg("Opened DB connection");
+                        IDbConnection dbcon = (IDbConnection)sf_instance.Dbcon;
+                        IDbCommand dbCommand = dbcon.CreateCommand();
+                        IDbCommand cmndReadFile = dbcon.CreateCommand();
+                        IDbCommand cmndReadImg = dbcon.CreateCommand();
+                        IDataReader readerFile;
+                        IDataReader readerImg;
+                        FieldInfo dbTableNameField = typeSF.GetField("dbTableName", BindingFlags.NonPublic | BindingFlags.Instance);
+
+                        //get song info from DB
+                        string queryGetFile = "SELECT image_file FROM " + dbTableNameField.GetValue(sf_instance) + " WHERE file_name='" + synthFile.Name + "'"; // private field dbTableName
+                        MelonLogger.Msg(queryGetFile);
+                        cmndReadFile.CommandText = queryGetFile;
+                        readerFile = cmndReadFile.ExecuteReader();
+                        readerFile.Read();
+                        imageFilePath = readerFile[0].ToString();
+                        readerFile.Close();
+
+                        //check for duplicate image files
+                        string queryGetImg = "SELECT image_file FROM " + dbTableNameField.GetValue(sf_instance) + " WHERE image_file='" + imageFilePath + "'"; // private field dbTableName
+                        MelonLogger.Msg(queryGetImg);
+                        cmndReadFile.CommandText = queryGetImg;
+                        readerImg = cmndReadFile.ExecuteReader();
+                        while (readerImg.Read())
+                        {
+                            count = count + 1;
+                        }
+                        readerImg.Close();
+                        if (count > 1)
+                        {
+                            isDuplicate = true;
+                        }
+
+                        //delete song info from db
+                        MelonLogger.Msg("Creating query");
+                        string queryDelete = "DELETE FROM " + dbTableNameField.GetValue(sf_instance) + " WHERE file_name='" + synthFile.Name + "'"; // private field dbTableName
+                        MelonLogger.Msg(queryDelete);
+                        dbCommand.CommandText = queryDelete;
+                        MelonLogger.Msg("Executing query");
+                        dbCommand.ExecuteNonQuery();
+                        MelonLogger.Msg("Deleted song from DB");
+                    }
+                    catch (Exception ex)
+                    {
+                        MelonLogger.Msg("Failed to access DB");
+                        MelonLogger.Msg(ex);
+
+                        if (sf_instance.Dbcon != null)
+                        {
+                            sf_instance.Dbcon.Close();
+                        }
+                        sf_instance.Dbcon = null;
+                        return;
+                    }
+
+                    // delete synth-file
+                    FieldInfo isSongLoadedField = ssm.GetField("waitForSongsLoad", BindingFlags.NonPublic | BindingFlags.Instance);
+                    while ((bool)isSongLoadedField.GetValue(ssmInstance))
+                    {
+                        Task.Delay(100);
+                    }
+                    try
+                    {
+                        if (File.Exists(filePath))
+                        {
+                            File.Delete(filePath);
+                            MelonLogger.Msg("Deleted synth file " + ssmInstance.SelectedGameTrack.m_name);
+                        }
+                        if (!isDuplicate)
+                        {
+                            if (File.Exists(mainDirPath + "/NmBlacklist.json"))
+                            {
+                                blacklist = JsonConvert.DeserializeObject<List<string>>(File.ReadAllText(mainDirPath + "/NmBlacklist.json"));
+                                blacklist.Add(synthFile.Name);
+                                MelonLogger.Msg("test");
+                                File.WriteAllText(mainDirPath + "/NmBlacklist.json", JsonConvert.SerializeObject(blacklist));
+                            }
+                            else
+                            {
+                                StreamWriter blacklistStream = File.AppendText(mainDirPath + "/NmBlacklist.json");
+                                blacklist.Add(synthFile.Name);
+                                blacklistStream.Write(JsonConvert.SerializeObject(blacklist));
+                                blacklistStream.Close();
+                            }
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        MelonLogger.Msg("Loading ongoing");
+                        MelonLogger.Msg(ex);
+                        return;
+                    }
+
+                    //Delete coresponding image file and leftover audio file
+                    if (File.Exists(imageFilePath) & (!isDuplicate))
+                    {
+                        File.Delete(imageFilePath);
+                        MelonLogger.Msg("Deleted image file");
+                    }
+
+                    Type sf = typeof(SynthsFinder);
+                    FieldInfo audioFilePathField = sf.GetField("AudioFileCachePath", BindingFlags.NonPublic | BindingFlags.Instance);
+                    string audioFilePath = (string)audioFilePathField.GetValue(sf_instance);
+
+                    // reload song list 
+                    ssmInstance.RefreshSongList(false);
+                    MelonLogger.Msg("Updated song list"); // use RefreshCustomSongs() instead?
+
+                }
+                else
+                {
+                    GameObject deleteButton = GameObject.Find("DeleteSongButton");
+                    Transform tooltip = deleteButton.transform.Find("Tooltip");
+                    Transform tooltipText = tooltip.Find("Text");
+                    tooltipText.GetComponentInChildren<TMPro.TMP_Text>().text = "Can't delete OST songs";
+                    MelonLogger.Msg("Can't delete OST songs");
+                    warnTimer.Elapsed += new ElapsedEventHandler(TimerEvent);
+                    warnTimer.AutoReset = true;
+                    warnTimer.Start();
+                }
+            }            
+        }
+       
+        public void TimerEvent(object sender, ElapsedEventArgs e)
+        {
+            GameObject deleteButton = GameObject.Find("DeleteSongButton");
+            Transform tooltip = deleteButton.transform.Find("Tooltip");
+            Transform tooltipText = tooltip.Find("Text");
+            tooltipText.GetComponentInChildren<TMPro.TMP_Text>().text = "Delete current song";
+            warnTimer.Stop();
+        }
+     
         public override void OnApplicationQuit()
         {
             base.OnApplicationQuit();

--- a/Trashbin.csproj
+++ b/Trashbin.csproj
@@ -32,21 +32,19 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Assembly-CSharp">
-      <HintPath>H:\Program Files (x86)\Steam\steamapps\common\SynthRiders\SynthRiders_Data\Managed\Assembly-CSharp.dll</HintPath>
+      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\SynthRiders\SynthRiders_Data\Managed\Assembly-CSharp.dll</HintPath>
     </Reference>
     <Reference Include="MelonLoader">
-      <HintPath>H:\Program Files (x86)\Steam\steamapps\common\SynthRiders\MelonLoader\MelonLoader.dll</HintPath>
+      <HintPath>..\..\..\..\Documents\Synth Riders Noodle Manager\MelonLoader\MelonLoader\MelonLoader.dll</HintPath>
     </Reference>
-    <Reference Include="Mono.Data.Sqlite, Version=2.0.0.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>H:\Program Files (x86)\Steam\steamapps\common\SynthRiders\SynthRiders_Data\Managed\Mono.Data.Sqlite.dll</HintPath>
+    <Reference Include="Mono.Data.Sqlite">
+      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\SynthRiders\SynthRiders_Data\Managed\Mono.Data.Sqlite.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>packages\Newtonsoft.Json.13.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json">
+      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\SynthRiders\SynthRiders_Data\Managed\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="PhotonUnityNetworking, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>H:\Program Files (x86)\Steam\steamapps\common\SynthRiders\SynthRiders_Data\Managed\PhotonUnityNetworking.dll</HintPath>
+    <Reference Include="PhotonUnityNetworking">
+      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\SynthRiders\SynthRiders_Data\Managed\PhotonUnityNetworking.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -57,52 +55,41 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
-    <Reference Include="Unity.TextMeshPro, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>H:\Program Files (x86)\Steam\steamapps\common\SynthRiders\SynthRiders_Data\Managed\Unity.TextMeshPro.dll</HintPath>
+    <Reference Include="Unity.TextMeshPro">
+      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\SynthRiders\SynthRiders_Data\Managed\Unity.TextMeshPro.dll</HintPath>
     </Reference>
-    <Reference Include="UnityEngine, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>H:\Program Files (x86)\Steam\steamapps\common\SynthRiders\SynthRiders_Data\Managed\UnityEngine.dll</HintPath>
+    <Reference Include="UnityEngine">
+      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\SynthRiders\SynthRiders_Data\Managed\UnityEngine.dll</HintPath>
     </Reference>
-    <Reference Include="UnityEngine.AudioModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>H:\Program Files (x86)\Steam\steamapps\common\SynthRiders\SynthRiders_Data\Managed\UnityEngine.AudioModule.dll</HintPath>
+    <Reference Include="UnityEngine.AudioModule">
+      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\SynthRiders\SynthRiders_Data\Managed\UnityEngine.AudioModule.dll</HintPath>
     </Reference>
-    <Reference Include="UnityEngine.CoreModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>H:\Program Files (x86)\Steam\steamapps\common\SynthRiders\SynthRiders_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
+    <Reference Include="UnityEngine.CoreModule">
+      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\SynthRiders\SynthRiders_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
     </Reference>
-    <Reference Include="UnityEngine.ImageConversionModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>H:\Program Files (x86)\Steam\steamapps\common\SynthRiders\SynthRiders_Data\Managed\UnityEngine.ImageConversionModule.dll</HintPath>
+    <Reference Include="UnityEngine.ImageConversionModule">
+      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\SynthRiders\SynthRiders_Data\Managed\UnityEngine.ImageConversionModule.dll</HintPath>
     </Reference>
-    <Reference Include="UnityEngine.UI, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>H:\Program Files (x86)\Steam\steamapps\common\SynthRiders\SynthRiders_Data\Managed\UnityEngine.UI.dll</HintPath>
+    <Reference Include="UnityEngine.UI">
+      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\SynthRiders\SynthRiders_Data\Managed\UnityEngine.UI.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.UnityTestProtocolModule">
-      <HintPath>H:\Program Files (x86)\Steam\steamapps\common\SynthRiders\SynthRiders_Data\Managed\UnityEngine.UnityTestProtocolModule.dll</HintPath>
+      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\SynthRiders\SynthRiders_Data\Managed\UnityEngine.UnityTestProtocolModule.dll</HintPath>
     </Reference>
-    <Reference Include="UnityEngine.UnityWebRequestAssetBundleModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>H:\Program Files (x86)\Steam\steamapps\common\SynthRiders\SynthRiders_Data\Managed\UnityEngine.UnityWebRequestAssetBundleModule.dll</HintPath>
+    <Reference Include="UnityEngine.UnityWebRequestAssetBundleModule">
+      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\SynthRiders\SynthRiders_Data\Managed\UnityEngine.UnityWebRequestAssetBundleModule.dll</HintPath>
     </Reference>
-    <Reference Include="UnityEngine.UnityWebRequestAudioModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>H:\Program Files (x86)\Steam\steamapps\common\SynthRiders\SynthRiders_Data\Managed\UnityEngine.UnityWebRequestAudioModule.dll</HintPath>
+    <Reference Include="UnityEngine.UnityWebRequestAudioModule">
+      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\SynthRiders\SynthRiders_Data\Managed\UnityEngine.UnityWebRequestAudioModule.dll</HintPath>
     </Reference>
-    <Reference Include="UnityEngine.UnityWebRequestModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>H:\Program Files (x86)\Steam\steamapps\common\SynthRiders\SynthRiders_Data\Managed\UnityEngine.UnityWebRequestModule.dll</HintPath>
+    <Reference Include="UnityEngine.UnityWebRequestModule">
+      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\SynthRiders\SynthRiders_Data\Managed\UnityEngine.UnityWebRequestModule.dll</HintPath>
     </Reference>
-    <Reference Include="UnityEngine.UnityWebRequestTextureModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>H:\Program Files (x86)\Steam\steamapps\common\SynthRiders\SynthRiders_Data\Managed\UnityEngine.UnityWebRequestTextureModule.dll</HintPath>
+    <Reference Include="UnityEngine.UnityWebRequestTextureModule">
+      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\SynthRiders\SynthRiders_Data\Managed\UnityEngine.UnityWebRequestTextureModule.dll</HintPath>
     </Reference>
-    <Reference Include="UnityEngine.UnityWebRequestWWWModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>H:\Program Files (x86)\Steam\steamapps\common\SynthRiders\SynthRiders_Data\Managed\UnityEngine.UnityWebRequestWWWModule.dll</HintPath>
+    <Reference Include="UnityEngine.UnityWebRequestWWWModule">
+      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\SynthRiders\SynthRiders_Data\Managed\UnityEngine.UnityWebRequestWWWModule.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
I repurposed the `TwoButtonsPromptWrap` found in the `SongSelectionManager`.  Whenever `SongSelectionManager.OpenPromptPanel` is called, its `int` argument triggers native game logic to change the text displayed in the prompt, and subsequently affects what actions occur when the `Continue` button is pressed, calling the `SongSelectionManager.OnPromptAccept` method.  

To avoid unwanted behaviors, I called `OpenPromptPanel` with a unique `int` argument value that avoids unwanted native game behaviors, and I added a new event listener to the `Continue` button that checks for my unique `int` argument value before performing the `Trashbin` logic to delete & blacklist the song.  In this way, both the native and new events will be called whenever the buttons are used for any purpose, but the unique `int` ensures that only the desired logic is executed.